### PR TITLE
Use PSR7 instead of Slim

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
     ],
     "require": {
         "php": "^7.0",
-        "dflydev/fig-cookies": "^1.0"
+        "dflydev/fig-cookies": "^1.0",
+        "psr/http-message": "^1.0"
     },
     "require-dev": {
         "eaglewu/swoole-ide-helper": "dev-master",

--- a/src/Bridge/ResponseMergerInterface.php
+++ b/src/Bridge/ResponseMergerInterface.php
@@ -2,19 +2,19 @@
 
 namespace Pachico\SlimSwoole\Bridge;
 
-use Slim\Http;
+use Psr\Http\Message\ResponseInterface;
 use swoole_http_response;
 
 interface ResponseMergerInterface
 {
     /**
-     * @param Http\Response $slimResponse
+     * @param ResponseInterface $response
      * @param swoole_http_response $swooleResponse
      *
      * @return swoole_http_response
      */
     public function mergeToSwoole(
-        Http\Response $slimResponse,
+        ResponseInterface $response,
         swoole_http_response $swooleResponse
     ): swoole_http_response;
 }

--- a/tests/Unit/Bridge/ResponseMergerTest.php
+++ b/tests/Unit/Bridge/ResponseMergerTest.php
@@ -22,11 +22,6 @@ class ResponseMergerTest extends \Pachico\SlimSwooleUnitTest\AbstractTestCase
     /**
      * @var PHPUnit_Framework_MockObject_MockObject
      */
-    private $slimResponse;
-
-    /**
-     * @var PHPUnit_Framework_MockObject_MockObject
-     */
     private $body;
 
     /**
@@ -50,8 +45,6 @@ class ResponseMergerTest extends \Pachico\SlimSwooleUnitTest\AbstractTestCase
 
         $this->swooleResponse = $this->getMockBuilder('\swoole_http_response')->disableOriginalConstructor()->getMock();
         $this->body = $this->getMockForAbstractClass(\Psr\Http\Message\StreamInterface::class);
-        $this->slimResponse = $this->getMockBuilder(Http\Response::class)->disableOriginalConstructor()->getMock();
-        $this->slimResponse->expects($this->any())->method('getBody')->willReturn($this->body);
         $this->psrResponse = $this->getMockBuilder(ResponseInterface::class)->getMockForAbstractClass();
         $this->psrResponse->expects($this->any())->method('getBody')->willReturn($this->body);
         $this->container = $this->getMockBuilder(\Slim\Container::class)->disableOriginalConstructor()->getMock();
@@ -59,15 +52,6 @@ class ResponseMergerTest extends \Pachico\SlimSwooleUnitTest\AbstractTestCase
         $this->app->expects($this->any())->method('getContainer')->willReturn($this->container);
 
         $this->sut = new Bridge\ResponseMerger($this->app);
-    }
-
-    public function testMergeToSwooleReturnsSlimResponse()
-    {
-        // Arrange
-        // Act
-        $output = $this->sut->mergeToSwoole($this->slimResponse, $this->swooleResponse);
-        // Assert
-        $this->assertInstanceOf('\swoole_http_response', $output);
     }
 
     public function testMergeToSwooleReturnsPsrResponse()
@@ -88,7 +72,7 @@ class ResponseMergerTest extends \Pachico\SlimSwooleUnitTest\AbstractTestCase
         $this->body->expects($this->any())->method('getSize')->willReturn(77);
         $this->swooleResponse->expects($headerSpy = $this->once())->method('header')->with('Content-Length', '77');
         // Act
-        $this->sut->mergeToSwoole($this->slimResponse, $this->swooleResponse);
+        $this->sut->mergeToSwoole($this->psrResponse, $this->swooleResponse);
         // Assert
         $this->assertSame(1, $headerSpy->getInvocationCount());
     }
@@ -102,7 +86,7 @@ class ResponseMergerTest extends \Pachico\SlimSwooleUnitTest\AbstractTestCase
         $this->body->expects($this->any())->method('getSize')->willReturn(77);
         $this->swooleResponse->expects($headerSpy = $this->never())->method('header')->with('Content-Length', '77');
         // Act
-        $this->sut->mergeToSwoole($this->slimResponse, $this->swooleResponse);
+        $this->sut->mergeToSwoole($this->psrResponse, $this->swooleResponse);
         // Assert
         $this->assertSame(0, $headerSpy->getInvocationCount());
     }
@@ -110,13 +94,13 @@ class ResponseMergerTest extends \Pachico\SlimSwooleUnitTest\AbstractTestCase
     public function testHeadersGetCopied()
     {
         // Arrange
-        $this->slimResponse->expects($this->any())->method('getHeaders')->willReturn([
+        $this->psrResponse->expects($this->any())->method('getHeaders')->willReturn([
             'foo' => ['bar'],
             'fiz' => ['bam']
         ]);
         $this->swooleResponse->expects($headerSpy = $this->exactly(2))->method('header');
         // Act
-        $this->sut->mergeToSwoole($this->slimResponse, $this->swooleResponse);
+        $this->sut->mergeToSwoole($this->psrResponse, $this->swooleResponse);
         // Assert
         $this->assertSame(2, $headerSpy->getInvocationCount());
     }
@@ -131,7 +115,7 @@ class ResponseMergerTest extends \Pachico\SlimSwooleUnitTest\AbstractTestCase
         $this->body->expects($this->once())->method('getContents')->willReturn('abc');
         $this->swooleResponse->expects($writeSpy = $this->once())->method('write')->with('abc');
         // Act
-        $this->sut->mergeToSwoole($this->slimResponse, $this->swooleResponse);
+        $this->sut->mergeToSwoole($this->psrResponse, $this->swooleResponse);
 
         // Assert
         $this->assertSame(1, $rewindSpy->getInvocationCount());
@@ -141,10 +125,10 @@ class ResponseMergerTest extends \Pachico\SlimSwooleUnitTest\AbstractTestCase
     public function testStatusCodeGetsCopied()
     {
         // Arrange
-        $this->slimResponse->expects($this->once())->method('getStatusCode')->willReturn(400);
+        $this->psrResponse->expects($this->once())->method('getStatusCode')->willReturn(400);
         $this->swooleResponse->expects($setStatusSpy = $this->once())->method('status')->with(400);
         // Act
-        $this->sut->mergeToSwoole($this->slimResponse, $this->swooleResponse);
+        $this->sut->mergeToSwoole($this->psrResponse, $this->swooleResponse);
 
         // Assert
         $this->assertSame(1, $setStatusSpy->getInvocationCount());

--- a/tests/Unit/Bridge/ResponseMergerTest.php
+++ b/tests/Unit/Bridge/ResponseMergerTest.php
@@ -3,10 +3,16 @@
 namespace Pachico\SlimSwooleUnitTest\Bridge;
 
 use Pachico\SlimSwoole\Bridge;
+use Psr\Http\Message\ResponseInterface;
 use Slim\Http;
 
 class ResponseMergerTest extends \Pachico\SlimSwooleUnitTest\AbstractTestCase
 {
+
+    /**
+     * @var PHPUnit_Framework_MockObject_MockObject
+     */
+    private $psrResponse;
 
     /**
      * @var PHPUnit_Framework_MockObject_MockObject
@@ -46,6 +52,8 @@ class ResponseMergerTest extends \Pachico\SlimSwooleUnitTest\AbstractTestCase
         $this->body = $this->getMockForAbstractClass(\Psr\Http\Message\StreamInterface::class);
         $this->slimResponse = $this->getMockBuilder(Http\Response::class)->disableOriginalConstructor()->getMock();
         $this->slimResponse->expects($this->any())->method('getBody')->willReturn($this->body);
+        $this->psrResponse = $this->getMockBuilder(ResponseInterface::class)->getMockForAbstractClass();
+        $this->psrResponse->expects($this->any())->method('getBody')->willReturn($this->body);
         $this->container = $this->getMockBuilder(\Slim\Container::class)->disableOriginalConstructor()->getMock();
         $this->app = $this->getMockBuilder(\Slim\App::class)->disableOriginalConstructor()->getMock();
         $this->app->expects($this->any())->method('getContainer')->willReturn($this->container);
@@ -58,6 +66,15 @@ class ResponseMergerTest extends \Pachico\SlimSwooleUnitTest\AbstractTestCase
         // Arrange
         // Act
         $output = $this->sut->mergeToSwoole($this->slimResponse, $this->swooleResponse);
+        // Assert
+        $this->assertInstanceOf('\swoole_http_response', $output);
+    }
+
+    public function testMergeToSwooleReturnsPsrResponse()
+    {
+        // Arrange
+        // Act
+        $output = $this->sut->mergeToSwoole($this->psrResponse, $this->swooleResponse);
         // Assert
         $this->assertInstanceOf('\swoole_http_response', $output);
     }


### PR DESCRIPTION
this could be useful, if in slim if you use another http client and want to return the response directly without first converting it to a slim response. The slim response is psr compliant anyway