### PR TITLE
Cookies should be merge with "cookie" method instead of "header"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         }
     ],
     "require": {
-        "php": "^7.0"
+        "php": "^7.0",
+        "dflydev/fig-cookies": "^1.0"
     },
     "require-dev": {
         "eaglewu/swoole-ide-helper": "dev-master",

--- a/src/Bridge/RequestTransformer.php
+++ b/src/Bridge/RequestTransformer.php
@@ -29,6 +29,7 @@ class RequestTransformer implements RequestTransformerInterface
                     'REQUEST_URI' => $request->server['request_uri'],
                     'QUERY_STRING' => isset($request->server['query_string']) ? $request->server['query_string'] : '',
                     'SERVER_PORT' => $request->server['server_port'],
+                    'SERVER_NAME' => $request->header['host'],
                     'REMOTE_ADDR' => $request->server['remote_addr'],
                     'REQUEST_TIME' => $request->server['request_time'],
                     'REQUEST_TIME_FLOAT' => $request->server['request_time_float']
@@ -97,7 +98,6 @@ class RequestTransformer implements RequestTransformerInterface
      */
     private function copyHeaders(swoole_http_request $request, Http\Request $slimRequest): Http\Request
     {
-
         foreach ($request->header as $key => $val) {
             $slimRequest = $slimRequest->withHeader($key, $val);
         }

--- a/src/Bridge/RequestTransformer.php
+++ b/src/Bridge/RequestTransformer.php
@@ -4,6 +4,8 @@ namespace Pachico\SlimSwoole\Bridge;
 
 use Slim\Http;
 use swoole_http_request;
+use Dflydev\FigCookies\Cookie;
+use Dflydev\FigCookies\FigRequestCookies;
 
 class RequestTransformer implements RequestTransformerInterface
 {
@@ -43,7 +45,29 @@ class RequestTransformer implements RequestTransformerInterface
             $slimRequest = $this->handleUploadedFiles($request, $slimRequest);
         }
 
+        $slimRequest = $this->copyCookies($request, $slimRequest);
+
         return $this->copyBody($request, $slimRequest);
+    }
+
+    /**
+     * @param swoole_http_request $request
+     * @param Http\Request $slimRequest
+     *
+     * @return Http\Request
+     */
+    private function copyCookies(swoole_http_request $request, Http\Request $slimRequest): Http\Request
+    {
+        if (empty($request->cookie)) {
+            return $slimRequest;
+        }
+
+        foreach ($request->cookie as $name => $value) {
+            $cookie = Cookie::create($name, $value);
+            $slimRequest = FigRequestCookies::set($slimRequest, $cookie);
+        }
+
+        return $slimRequest;
     }
 
     /**

--- a/tests/Unit/Bridge/RequestTransformerTest.php
+++ b/tests/Unit/Bridge/RequestTransformerTest.php
@@ -35,7 +35,9 @@ class RequestTransformerTest extends \Pachico\SlimSwooleUnitTest\AbstractTestCas
             'request_time' => '1514764800',
             'request_time_float' => '1514764800.000',
         ];
-        $this->swooleRequest->header = [];
+        $this->swooleRequest->header = [
+            'host' => 'example.com',
+        ];
 
         $this->sut = new Bridge\RequestTransformer();
     }
@@ -63,10 +65,13 @@ class RequestTransformerTest extends \Pachico\SlimSwooleUnitTest\AbstractTestCas
     public function testPostDataGetsCopiedIfExistsAndIsMultipartFormData()
     {
         // Arrange
-        $this->swooleRequest->header = [
-            'content-type' => 'multipart/form-data',
-            'foo' => 'bar'
-        ];
+        $this->swooleRequest->header = array_merge(
+            $this->swooleRequest->header,
+            [
+                'content-type' => 'multipart/form-data',
+                'foo' => 'bar'
+            ]
+        );
         $this->swooleRequest->post = [
             'foo' => 'bar'
         ];
@@ -81,9 +86,12 @@ class RequestTransformerTest extends \Pachico\SlimSwooleUnitTest\AbstractTestCas
     public function testPostDataGetsCopiedIfExistsAndXWwwFormUrlEncoded()
     {
         // Arrange
-        $this->swooleRequest->header = [
-            'content-type' => 'application/x-www-form-urlencoded'
-        ];
+        $this->swooleRequest->header = array_merge(
+            $this->swooleRequest->header,
+            [
+                'content-type' => 'application/x-www-form-urlencoded'
+            ]
+        );
         $this->swooleRequest->post = [
             'foo' => 'bar'
         ];
@@ -98,7 +106,10 @@ class RequestTransformerTest extends \Pachico\SlimSwooleUnitTest\AbstractTestCas
     public function testUploadedFilesAreCopiedProperty()
     {
         // Arrange
-        $this->swooleRequest->header = ['content-type' => 'multipart/form-data'];
+        $this->swooleRequest->header = array_merge(
+            $this->swooleRequest->header,
+            ['content-type' => 'multipart/form-data']
+        );
         $this->swooleRequest->files = [
             'name1' => [
                 'tmp_name' => 'tmp1',
@@ -150,5 +161,12 @@ class RequestTransformerTest extends \Pachico\SlimSwooleUnitTest\AbstractTestCas
         $cookies = Cookies::fromRequest($output)->getAll();
         $this->assertEquals(count($cookies), 3);
         $this->assertEquals(FigRequestCookies::get($output, 'some-cookie-2')->getValue(), 'some-value-2');
+    }
+
+    public function testHostHeaderIsCopiedProperly()
+    {
+        // Act
+        $output = $this->sut->toSlim($this->swooleRequest);
+        $this->assertEquals($output->getUri()->getHost(), 'example.com');
     }
 }

--- a/tests/Unit/Bridge/RequestTransformerTest.php
+++ b/tests/Unit/Bridge/RequestTransformerTest.php
@@ -4,6 +4,8 @@ namespace Pachico\SlimSwooleUnitTest\Bridge;
 
 use Pachico\SlimSwoole\Bridge;
 use Slim\Http;
+use Dflydev\FigCookies\Cookies;
+use Dflydev\FigCookies\FigRequestCookies;
 
 class RequestTransformerTest extends \Pachico\SlimSwooleUnitTest\AbstractTestCase
 {
@@ -131,5 +133,22 @@ class RequestTransformerTest extends \Pachico\SlimSwooleUnitTest\AbstractTestCas
         $this->assertSame($output->getUploadedFiles()['name2']->getClientMediaType(), 'type2');
         $this->assertSame($output->getUploadedFiles()['name2']->getError(), 0);
         $this->assertSame($output->getUploadedFiles()['name2']->getSize(), 88);
+    }
+
+    public function testCookiesAreCopiedProperly()
+    {
+        $this->swooleRequest->cookie = [
+            'some-cookie-1' => 'some-value-1',
+            'some-cookie-2' => 'some-value-2',
+            'some-cookie-3' => 'some-value-3',
+        ];
+
+        // Act
+        $output = $this->sut->toSlim($this->swooleRequest);
+
+        // Assert
+        $cookies = Cookies::fromRequest($output)->getAll();
+        $this->assertEquals(count($cookies), 3);
+        $this->assertEquals(FigRequestCookies::get($output, 'some-cookie-2')->getValue(), 'some-value-2');
     }
 }

--- a/tests/Unit/Bridge/ResponseMergerTest.php
+++ b/tests/Unit/Bridge/ResponseMergerTest.php
@@ -98,11 +98,47 @@ class ResponseMergerTest extends \Pachico\SlimSwooleUnitTest\AbstractTestCase
             'foo' => ['bar'],
             'fiz' => ['bam']
         ]);
+        $this->psrResponse->method('getHeader')->willReturn([]);
+        $this->psrResponse->method('withoutHeader')->willReturn($this->psrResponse);
+
         $this->swooleResponse->expects($headerSpy = $this->exactly(2))->method('header');
         // Act
         $this->sut->mergeToSwoole($this->psrResponse, $this->swooleResponse);
         // Assert
         $this->assertSame(2, $headerSpy->getInvocationCount());
+    }
+
+    public function testCookiesShouldBeMergedWithCookieMethod()
+    {
+        $psrResponseWithoutCookies = clone $this->psrResponse;
+        $psrResponseWithoutCookies->method('getHeaders')->willReturn([]);
+        $this->psrResponse->method('withoutHeader')->willReturn($psrResponseWithoutCookies);
+
+        $expires = new \Datetime('+2 hours');
+
+        // Fri, 05 Jul 2024 19:23:47 GMT
+        // Fri, 05 Jul 2019 20:57:00 GMT
+        
+        $cookieArray = [
+            'Cookie1=Value1; Domain=some-domain; Path=/; Expires=' . $expires->format(\DateTime::COOKIE) . ' GMT; Secure; HttpOnly',
+        ];
+
+        // Arrange
+        $this->psrResponse->expects($this->any())->method('getHeaders')->willReturn([
+            'Set-Cookie' => $cookieArray
+        ]);
+
+        $this->psrResponse->method('getHeader')->willReturn($cookieArray);
+        $this->psrResponse->method('hasHeader')->willReturn(true);
+
+        $this->swooleResponse->expects($headerSpy = $this->exactly(0))->method('header');
+        $this->swooleResponse->expects($cookieSpy = $this->exactly(1))->method('cookie')
+            ->with('Cookie1', 'Value1', $expires->getTimestamp(), '/', 'some-domain', true, true);
+        // Act
+        $this->sut->mergeToSwoole($this->psrResponse, $this->swooleResponse);
+        // Assert
+        $this->assertSame(0, $headerSpy->getInvocationCount());
+        $this->assertSame(1, $cookieSpy->getInvocationCount());
     }
 
     public function testBodyContentGetsCopiedIfNotEmpty()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When you set several cookies, merging with header method of swoole, you will get all the cookies under only one Set-Cookie header. Example: 

```
HTTP/1.1 200 OK
Set-Cookie: Cookie1=Value1; Cookie2=Value2; Cookie3=Value3
Server: swoole-http-server
```
The correct way should be:

```
HTTP/1.1 200 OK
Set-Cookie: Cookie1=Value1
Set-Cookie: Cookie2=Value2
Set-Cookie: Cookie3=Value3
Server: swoole-http-server
```
This is accomplished with the cookie method from swoole server.

## Motivation and context

This is for setting cookies in the right way.

## How has this been tested?

To test this:

```
<?php
require __DIR__ . '/vendor/autoload.php';

use Dflydev\FigCookies\SetCookie;
use Dflydev\FigCookies\SetCookies;

$container = new \Slim\Container();
$app = new \Slim\App($container);

$app->get('/', function ($request, $response) {
    $cookies = [
        SetCookie::create('Cookie1', 'Value1'),
        SetCookie::create('Cookie2', 'Value2'),
        SetCookie::create('Cookie3', 'Value3'),
    ];

    $setCookies = new SetCookies($cookies);

    return $setCookies->renderIntoSetCookieHeader($response);
});

$bridgeManager = new \Pachico\SlimSwoole\BridgeManager($app);

$server = new swoole_http_server('0.0.0.0', 9503, SWOOLE_PROCESS);

$server->on(
    'request',
    function ($request, $response) use ($bridgeManager) {
        $bridgeManager->process($request, $response)->end();
    }
);

$server->start();

```

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [ ] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
