### PR TITLE
write chunks of streams to swoole response

### DIFF
--- a/src/Bridge/ResponseMerger.php
+++ b/src/Bridge/ResponseMerger.php
@@ -8,6 +8,8 @@ use swoole_http_response;
 
 class ResponseMerger implements ResponseMergerInterface
 {
+    const FSTAT_MODE_S_IFIFO = 0010000;
+    
     /**
      * @var App
      */
@@ -55,6 +57,21 @@ class ResponseMerger implements ResponseMergerInterface
             }
 
             $swooleResponse->write($response->getBody()->getContents());
+            return $swooleResponse;
+        }
+        
+        $resource = $response->getBody()->detach();
+
+        if (is_resource($resource)) {
+            $stat = fstat($resource);
+
+            if (isset($stat['mode']) && ($stat['mode'] & self::FSTAT_MODE_S_IFIFO) !== 0) { // is a pipe?
+                while (!feof($resource)) {
+                    $buff = fread($resource, 8192);
+                    $swooleResponse->write($buff);
+                }
+                pclose($resource);
+            }
         }
 
         return $swooleResponse;

--- a/tests/Unit/Bridge/ResponseMergerTest.php
+++ b/tests/Unit/Bridge/ResponseMergerTest.php
@@ -122,6 +122,20 @@ class ResponseMergerTest extends \Pachico\SlimSwooleUnitTest\AbstractTestCase
         $this->assertSame(1, $writeSpy->getInvocationCount());
     }
 
+    public function testBodyContentGetsWrittenIfItIsAPipe()
+    {
+        // Arrange
+        $this->body->expects($this->once())->method('getSize')->willReturn(0);
+        $this->body->expects($this->any())->method('getMetadata')->willReturn(['mode' => 4480]); // named pipe (http://www.manpagez.com/man/2/stat/)
+        $this->body->expects($this->any())->method('detach')->willReturn(
+            popen('php -r "echo str_repeat(\'x\', 10000);"', 'r')
+        );
+        $this->swooleResponse->expects($writeSpy = $this->any())->method('write');
+
+        // Act
+        $this->sut->mergeToSwoole($this->psrResponse, $this->swooleResponse);
+    }
+
     public function testStatusCodeGetsCopied()
     {
         // Arrange


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR is to allow to write the output of a stream created with popen.

## Motivation and context

I have to compress and serve a bunch of files (ie: zip). The output must be written in chunks. With this change, the library could be used and detect if the Response contains a regular body or a resource and it will write it to Swoole response using the appropiated method.

## How has this been tested?

Tests were added.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
