### PR TITLE
add-reason-phrase-support

### DIFF
--- a/src/Bridge/ResponseMerger.php
+++ b/src/Bridge/ResponseMerger.php
@@ -47,7 +47,7 @@ class ResponseMerger implements ResponseMergerInterface
             }
         }
 
-        $swooleResponse->status($response->getStatusCode());
+        $swooleResponse->status($response->getStatusCode(), $response->getReasonPhrase());
 
         if ($response->getBody()->getSize() > 0) {
             if ($response->getBody()->isSeekable()) {

--- a/tests/Unit/Bridge/ResponseMergerTest.php
+++ b/tests/Unit/Bridge/ResponseMergerTest.php
@@ -125,8 +125,9 @@ class ResponseMergerTest extends \Pachico\SlimSwooleUnitTest\AbstractTestCase
     public function testStatusCodeGetsCopied()
     {
         // Arrange
-        $this->psrResponse->expects($this->once())->method('getStatusCode')->willReturn(400);
-        $this->swooleResponse->expects($setStatusSpy = $this->once())->method('status')->with(400);
+        $this->psrResponse->expects($this->once())->method('getStatusCode')->willReturn(235);
+        $this->psrResponse->expects($this->once())->method('getReasonPhrase')->willReturn('Unknown code');
+        $this->swooleResponse->expects($setStatusSpy = $this->once())->method('status')->with(235, 'Unknown code');
         // Act
         $this->sut->mergeToSwoole($this->psrResponse, $this->swooleResponse);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add reason phrase support

## Motivation and context

We need a custom http status code within a project, and it seems, that swoole itself does only support them with a given reason phrase.

## How has this been tested?

See Test change (Unit)

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

